### PR TITLE
Rename loxone_ingest → data_ingest; disable controller + web

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This is a consolidated Python service that combines multiple smart home automati
 |---|---|
 | **Server** | `ssh -p 2222 tom@192.168.0.201` (SSH key passphrase required) |
 | **Repo on server** | `/volume1/homes/tom/git/loxone-db-grafana/` |
-| **Containers** | **THREE**, all built from `./loxone_smart_home/` (same Dockerfile/context, **separate image tags**): `loxone_ingest` (the data-saving process — UDP listener + weather + OTE + MQTT bridge; owns the `2000/udp` publish), `loxone_smart_home` (the Growatt controller + the API on internal port 5556), and `loxone_web` (the public dashboard pages on 5555, proxies `/api/*` to `loxone_smart_home:5556`). Ingest and controller run the **same default entry point** (`main.py`) and are differentiated only by per-container `*_ENABLED` + `MQTT_CLIENT_ID` `environment:` overrides. See "Web/controller split" below. |
+| **Containers** | **Currently ONE active: `data_ingest`** (the data-saving process — UDP listener + weather + OTE + MQTT bridge; owns the `2000/udp` publish), built from `./loxone_smart_home/` running `main.py` with `GROWATT_CONTROLLER_ENABLED=false`. The other two — `loxone_smart_home` (the Growatt controller + the API on internal port 5556) and `loxone_web` (the public dashboard pages on 5555) — are **commented out in `docker-compose.yml`**: the controller is being **replaced by a separate MPC**. Uncomment both blocks to revive them. The notes below describe the full three-container split for when the controller returns. |
 | **Network** | `caddy_net` (external) — shares `influxdb`, `mosquitto`, Grafana with the `selfhosted` stack. The compose `environment:` block overrides `INFLUXDB_HOST=http://influxdb:8086` and `MQTT_BROKER=mosquitto` to reach them by container name. |
 | **Local repo** | `/Users/tom/git/LoxoneSmartHome` |
 | **selfhosted repo** | `/Users/tom/git/selfhosted` (local) / `/volume1/homes/tom/git/selfhosted` (server) — holds the Caddy config; the energy upstream points at `loxone_web:5555`. |
@@ -36,26 +36,26 @@ tar cf - \
 | ssh -p 2222 tom@192.168.0.201 \
   "cd /volume1/homes/tom/git/loxone-db-grafana/loxone_smart_home && tar xf - -v"
 
-# 2. Rebuild + restart. ALL THREE containers build from the same context but have
-#    SEPARATE image tags, so rebuild whichever the change affects (see the
-#    "which container" rule below). When in doubt, build all three.
+# 2. Rebuild + restart. Only data_ingest is active right now (controller +
+#    loxone_web are commented out in docker-compose.yml). Rebuild it after a
+#    data-module change; uncomment + build the others when the controller returns.
 ssh -p 2222 tom@192.168.0.201 bash -l << 'ENDSSH'
 cd /volume1/homes/tom/git/loxone-db-grafana
-docker-compose build loxone_ingest loxone_smart_home loxone_web
-docker-compose up -d loxone_ingest loxone_smart_home loxone_web
+docker-compose build data_ingest
+docker-compose up -d data_ingest
 ENDSSH
 
 # 3. Verify — tail logs (there is no healthcheck, so inspect Status, not Health)
 ssh -p 2222 tom@192.168.0.201 bash -l << 'ENDSSH'
-docker ps --format '{{.Names}}: {{.Status}}' | grep loxone
-docker logs loxone_smart_home --tail 50 2>&1 | sed 's/\x1b\[[0-9;]*m//g'
+docker ps --format '{{.Names}}: {{.Status}}' | grep -E 'data_ingest|loxone'
+docker logs data_ingest --tail 50 2>&1 | sed 's/\x1b\[[0-9;]*m//g'
 ENDSSH
 ```
 
 **Which container to rebuild** (the file decides):
-- Data-saving modules (`modules/udp_listener.py`, `modules/weather_scraper.py`, `modules/ote_price_collector.py`, `modules/mqtt_bridge.py`) → **`loxone_ingest`**. Restarting it does NOT touch the controller (no model rebuild / re-actuation). The Loxone `2000/udp` listener lives here.
+- Data-saving modules (`modules/udp_listener.py`, `modules/weather_scraper.py`, `modules/ote_price_collector.py`, `modules/mqtt_bridge.py`) → **`data_ingest`**. Restarting it does NOT touch the controller (no model rebuild / re-actuation). The Loxone `2000/udp` listener lives here.
 - Controller / Growatt async modules / the `/api/*` JSON+control handlers (`modules/growatt_controller.py`, `modules/growatt/*.py`, the `api_*` functions in `dashboard.py`) → **`loxone_smart_home`**. Recreating it restarts the controller (~30–40s: model rebuild, inverter re-actuation).
-- Shared code (`config/*`, `main.py`, `utils/*`, `requirements.txt`) affects BOTH `loxone_ingest` and `loxone_smart_home` (same image/entry point) — rebuild both.
+- Shared code (`config/*`, `main.py`, `utils/*`, `requirements.txt`) affects BOTH `data_ingest` and `loxone_smart_home` (same image/entry point) — rebuild both.
 - The dashboard **pages/HTML/JS** (`DASHBOARD_HTML`/`SETTINGS_HTML` and page handlers in `dashboard.py`, `run_web_apps.py`) → **`loxone_web`** only (restart is cheap; controller untouched). This is the whole point of the split — iterate on UI without bouncing the controller.
 - `modules/growatt/dashboard.py` contains BOTH the API handlers (main) and the page strings (web), so a change there usually means **rebuild both** `loxone_smart_home` + `loxone_web`.
 
@@ -67,12 +67,14 @@ Notes:
 
 ### Data/controller/web split, entry points & ports
 
+> **Current state:** only `data_ingest` runs. `loxone_smart_home` (controller) and `loxone_web` are commented out in `docker-compose.yml` because the controller is being replaced by a separate MPC. The rest of this section describes the full split as designed — it applies once those services are uncommented.
+
 Three containers, separated so each tier can be restarted independently:
 - **data ingestion** keeps filling InfluxDB even while the controller is bounced or swapped,
 - the **controller** can be replaced with a different one in the future without touching ingestion, and
 - the **UI** can be iterated without restarting the controller (which would retrain models + re-actuate the inverter).
 
-- **`loxone_ingest`** (image default CMD `run_integrated.py` → `main.py`, but with `GROWATT_CONTROLLER_ENABLED=false`): the data-saving modules only — UDP listener (Loxone → `loxone` bucket, owns `2000/udp`), weather scraper (→ `weather_forecast`), OTE price collector (→ `ote_prices`), and the MQTT→Loxone bridge. Writes nothing controller-derived. A future replacement controller reuses this unchanged. **Must have a distinct `MQTT_CLIENT_ID`** (`loxone-ingest`) — sharing the controller's id would make the two broker connections evict each other in a reconnect loop. All controller↔ingest coupling is via the shared mosquitto broker + InfluxDB (e.g. ingest publishes `loxone/status`; the controller's high-load detection subscribes), so they work fine in separate processes.
+- **`data_ingest`** (image default CMD `run_integrated.py` → `main.py`, but with `GROWATT_CONTROLLER_ENABLED=false`): the data-saving modules only — UDP listener (Loxone → `loxone` bucket, owns `2000/udp`), weather scraper (→ `weather_forecast`), OTE price collector (→ `ote_prices`), and the MQTT→Loxone bridge. Writes nothing controller-derived. A future replacement controller reuses this unchanged. **Must have a distinct `MQTT_CLIENT_ID`** (`data-ingest`) — sharing the controller's id would make the two broker connections evict each other in a reconnect loop. All controller↔ingest coupling is via the shared mosquitto broker + InfluxDB (e.g. ingest publishes `loxone/status`; the controller's high-load detection subscribes), so they work fine in separate processes.
 - **`loxone_smart_home`** (same image default CMD, with the data modules disabled via `UDP_LISTENER_ENABLED=false`/`WEATHER_SCRAPER_ENABLED=false`/`OTE_COLLECTOR_ENABLED=false`/`MQTT_BRIDGE_ENABLED=false` and `MQTT_CLIENT_ID=loxone-controller`): the controller + Growatt async modules, and the **controller-backed API app on internal port 5556** (`create_api_app` / `start_api_dashboard`). 5556 is `expose`d, NOT published. (`run_integrated.py` also *can* launch the `web/` FastAPI on 8080 when `WEB_SERVICE_ENABLED=true`, but it's **off in prod**.)
 - **`loxone_web`** (compose `command: ["python","run_web_apps.py"]`): serves the dashboard **pages** on **5555** (`create_pages_app`) and **reverse-proxies `/api/*`** (incl. the SSE log stream, via the streaming `_proxy_to_api`) to `DASHBOARD_API_UPSTREAM` (default `http://loxone_smart_home:5556`). Stateless — settings POSTs proxy to main, which persists.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,16 @@ version: "3.8"
 
 services:
   # =============================================================================
-  # Loxone Ingest - data-saving process (no controller).
-  # Built from the SAME image; runs the default entry point (main.py) but with
-  # only the data modules enabled: UDP listener (Loxone -> InfluxDB), weather
-  # scraper, OTE price collector, and the MQTT->Loxone bridge. Kept separate so
-  # the Growatt controller can be swapped/restarted without disrupting data
-  # ingestion. Owns the 2000/udp publish (the Loxone UDP listener lives here).
+  # Data Ingest - data-saving process (no controller).
+  # Runs the default entry point (main.py) but with only the data modules
+  # enabled: UDP listener (Loxone -> InfluxDB), weather scraper, OTE price
+  # collector, and the MQTT->Loxone bridge. Kept separate so a controller can be
+  # swapped/restarted without disrupting data ingestion. Owns the 2000/udp
+  # publish (the Loxone UDP listener lives here).
   # =============================================================================
-  loxone_ingest:
+  data_ingest:
     build: ./loxone_smart_home
-    container_name: loxone_ingest
+    container_name: data_ingest
     restart: unless-stopped
     ports:
       - "2000:2000/udp"
@@ -21,73 +21,69 @@ services:
       # Override to use services from selfhosted repo via caddy_net
       - INFLUXDB_HOST=http://influxdb:8086
       - MQTT_BROKER=mosquitto
-      # Unique broker client id (must differ from the controller's, or the two
+      # Unique broker client id (must differ from any controller's, or the two
       # connections evict each other in a reconnect loop).
-      - MQTT_CLIENT_ID=loxone-ingest
-      # Data modules only — controller runs in the loxone_smart_home container.
+      - MQTT_CLIENT_ID=data-ingest
+      # Data modules only — no controller runs in this process.
       - GROWATT_CONTROLLER_ENABLED=false
     networks:
       - caddy_net
 
   # =============================================================================
-  # Loxone Smart Home - the Growatt battery controller + dashboard API.
-  # Built from the SAME image / default entry point, but with the data modules
-  # disabled (they run in loxone_ingest). Reads telemetry/prices/weather from
-  # the shared InfluxDB + mosquitto broker on caddy_net.
+  # DISABLED — the Growatt controller (loxone_smart_home) and the dashboard web
+  # tier (loxone_web) are commented out: the controller is being REPLACED by a
+  # separate MPC. data_ingest above keeps all data flowing into InfluxDB in the
+  # meantime. To revive the old controller + dashboard, uncomment both blocks
+  # and run `docker-compose up -d`.
   # =============================================================================
-  loxone_smart_home:
-    build: ./loxone_smart_home
-    container_name: loxone_smart_home
-    restart: unless-stopped
-    # The controller-backed dashboard API listens on 5556 but is NOT published
-    # to the host — only the loxone_web container reaches it (by service name
-    # on caddy_net). The public pages are served by loxone_web on 5555.
-    expose:
-      - "5556"
-    env_file:
-      - ./loxone_smart_home/.env
-    environment:
-      # Override to use services from selfhosted repo via caddy_net
-      - INFLUXDB_HOST=http://influxdb:8086
-      - MQTT_BROKER=mosquitto
-      # Unique broker client id (must differ from loxone_ingest's).
-      - MQTT_CLIENT_ID=loxone-controller
-      # Controller only — the data modules run in loxone_ingest.
-      - UDP_LISTENER_ENABLED=false
-      - WEATHER_SCRAPER_ENABLED=false
-      - OTE_COLLECTOR_ENABLED=false
-      - MQTT_BRIDGE_ENABLED=false
-    volumes:
-      # Persist dashboard-edited config overrides across rebuilds. A named
-      # volume on a *directory* avoids the missing-file-becomes-a-directory
-      # bind-mount trap; the app writes config_overrides.json inside it.
-      - loxone_config_state:/app/config_state
-    networks:
-      - caddy_net
+  # loxone_smart_home:
+  #   build: ./loxone_smart_home
+  #   container_name: loxone_smart_home
+  #   restart: unless-stopped
+  #   # The controller-backed dashboard API listens on 5556 but is NOT published
+  #   # to the host — only the loxone_web container reaches it (by service name
+  #   # on caddy_net). The public pages are served by loxone_web on 5555.
+  #   expose:
+  #     - "5556"
+  #   env_file:
+  #     - ./loxone_smart_home/.env
+  #   environment:
+  #     # Override to use services from selfhosted repo via caddy_net
+  #     - INFLUXDB_HOST=http://influxdb:8086
+  #     - MQTT_BROKER=mosquitto
+  #     # Unique broker client id (must differ from data_ingest's).
+  #     - MQTT_CLIENT_ID=loxone-controller
+  #     # Controller only — the data modules run in data_ingest.
+  #     - UDP_LISTENER_ENABLED=false
+  #     - WEATHER_SCRAPER_ENABLED=false
+  #     - OTE_COLLECTOR_ENABLED=false
+  #     - MQTT_BRIDGE_ENABLED=false
+  #   volumes:
+  #     # Persist dashboard-edited config overrides across rebuilds. A named
+  #     # volume on a *directory* avoids the missing-file-becomes-a-directory
+  #     # bind-mount trap; the app writes config_overrides.json inside it.
+  #     - loxone_config_state:/app/config_state
+  #   networks:
+  #     - caddy_net
 
-  # =============================================================================
-  # Loxone Web - standalone web UI (dashboard pages + settings editor).
-  # Built from the SAME image; runs run_web_apps.py instead of the controller.
-  # Serves pages on 5555 and reverse-proxies /api/* to loxone_smart_home:5556,
-  # so the UI can be rebuilt/restarted without bouncing the controller (no
-  # model retraining / inverter re-actuation).
-  # =============================================================================
-  loxone_web:
-    build: ./loxone_smart_home
-    container_name: loxone_web
-    restart: unless-stopped
-    command: ["python", "run_web_apps.py"]
-    depends_on:
-      - loxone_smart_home
-    ports:
-      - "5555:5555"  # public dashboard pages (Caddy proxies here)
-    env_file:
-      - ./loxone_smart_home/.env
-    environment:
-      - DASHBOARD_API_UPSTREAM=http://loxone_smart_home:5556
-    networks:
-      - caddy_net
+  # loxone_web:
+  #   build: ./loxone_smart_home
+  #   container_name: loxone_web
+  #   restart: unless-stopped
+  #   command: ["python", "run_web_apps.py"]
+  #   depends_on:
+  #     - loxone_smart_home
+  #   ports:
+  #     - "5555:5555"  # public dashboard pages (Caddy proxies here)
+  #   env_file:
+  #     - ./loxone_smart_home/.env
+  #   environment:
+  #     - DASHBOARD_API_UPSTREAM=http://loxone_smart_home:5556
+  #   networks:
+  #     - caddy_net
 
+# Kept for when the controller (loxone_smart_home) above is revived — it persists
+# the dashboard-edited config overrides. Unused while only data_ingest runs.
 volumes:
   loxone_config_state:
 

--- a/loxone_smart_home/tests/unit/test_settings.py
+++ b/loxone_smart_home/tests/unit/test_settings.py
@@ -47,12 +47,12 @@ class TestSettings:
         distinct broker client id (sharing one makes the two MQTT connections
         evict each other), so lock in the env -> field -> property wiring.
         """
-        env_vars = {"MQTT_CLIENT_ID": "loxone-ingest", "INFLUXDB_TOKEN": "tok"}
+        env_vars = {"MQTT_CLIENT_ID": "data-ingest", "INFLUXDB_TOKEN": "tok"}
         with patch.dict("os.environ", env_vars):
             settings = Settings(influxdb_token="tok")
 
-            assert settings.mqtt_client_id == "loxone-ingest"
-            assert settings.mqtt.client_id == "loxone-ingest"
+            assert settings.mqtt_client_id == "data-ingest"
+            assert settings.mqtt.client_id == "data-ingest"
 
     def test_mqtt_client_id_default(self) -> None:
         """Without an override the client id keeps the historical default."""


### PR DESCRIPTION
## What

- **Rename** the data-saving service `loxone_ingest` → **`data_ingest`** (service name, `container_name`, and `MQTT_CLIENT_ID=data-ingest`).
- **Disable** the Growatt controller (`loxone_smart_home`) and dashboard (`loxone_web`) services — commented out in `docker-compose.yml`. The controller is being **replaced by a separate MPC**; `data_ingest` keeps all ingestion (UDP/Loxone, weather, OTE, MQTT bridge) flowing into InfluxDB in the meantime.
- Update `CLAUDE.md` (container table, deploy loop, split section) and the settings client-id test to match.

## Why

The NAS was already cut over to a standalone ingest process with the controller turned off (it's being retired in favor of an MPC). This codifies that state: only `data_ingest` is active, and the controller/web blocks are kept (commented) so they can be revived by uncommenting.

## Revert path

Uncomment the `loxone_smart_home` + `loxone_web` blocks in `docker-compose.yml` and `docker-compose up -d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)